### PR TITLE
Enable tests that are _still_ disabled

### DIFF
--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -40,6 +40,7 @@ from eth.vm.base import (
     BaseVM,
 )
 from eth.vm.forks import (
+    ConstantinopleVM,
     ByzantiumVM,
     TangerineWhistleVM,
     FrontierVM,
@@ -122,6 +123,10 @@ def chain_vm_configuration(fixture: Dict[str, Any]) -> Iterable[Tuple[int, Type[
     elif network == 'Byzantium':
         return (
             (0, ByzantiumVM),
+        )
+    elif network == 'Constantinople':
+        return (
+            (0, ConstantinopleVM),
         )
     elif network == 'FrontierToHomesteadAt5':
         HomesteadVM = BaseHomesteadVM.configure(support_dao_fork=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,13 @@ from eth.vm.forks.spurious_dragon import SpuriousDragonVM
 # Uncomment this to have logs from tests written to a file.  This is useful for
 # debugging when you need to dump the VM output from test runs.
 """
+import datetime
+import logging
+import os
+from eth.tools.logging import TRACE_LEVEL_NUM
+
 @pytest.yield_fixture(autouse=True)
 def _file_logging(request):
-    import datetime
-    import os
 
     logger = logging.getLogger('eth')
 

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -84,8 +84,6 @@ def fixture(fixture_data):
         fixture_key,
         normalize_blockchain_fixtures,
     )
-    if fixture['network'] == 'Constantinople':
-        pytest.skip('Constantinople VM rules not yet supported')
     return fixture
 
 

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -45,6 +45,11 @@ INCORRECT_UPSTREAM_TESTS = {
     # The result is in conflict with the yellow-paper:
     # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
     ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Byzantium'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Constantinople'),  # noqa: E501
+    # The CREATE2 variant seems to have been derived from the one above - it, too,
+    # has a "synthetic" state, on which py-evm flips.
+    # * https://github.com/ethereum/py-evm/pull/1181#issuecomment-446330609
+    ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_Constantinople'),  # noqa: E501
 }
 
 

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -146,6 +146,7 @@ INCORRECT_UPSTREAM_TESTS = {
     # The result is in conflict with the yellow-paper:
     # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
     ('stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit', 'Byzantium', 0),
+    ('stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit', 'Constantinople', 0),
 }
 
 


### PR DESCRIPTION
### What was wrong?

~~`CREATE2` was not acting `CREATE`-like.~~

Also, some `Constantinople` tests are still disabled.

### How was it fixed?

~~See explanation in https://github.com/ethereum/py-evm/pull/1181#issuecomment-445359189 or commit 00377ed.~~

~~Essential commit also submitted to `ethereum/py-evm` separately, as https://github.com/ethereum/py-evm/pull/1560.~~

Also, the other commits relevant to https://github.com/ethereum/py-evm/pull/1181 are included.


### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://noahsarkvet.us/files/2013/05/two-puppies.png)

Source: [Noah's Ark companion animal hospital in Franklin, NC](https://noahsarkvet.us/2013/05/01/getting-ready-for-puppy-season-in-franklin-nc-adopting-two-pups-together/)